### PR TITLE
Implemented reachability probe for endpoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 test
+.idea

--- a/haproxy.go
+++ b/haproxy.go
@@ -2,8 +2,8 @@ package main
 
 import (
   log "github.com/sirupsen/logrus"
-  "os/exec"
   "os"
+  "os/exec"
   "syscall"
 )
 

--- a/main.go
+++ b/main.go
@@ -2,14 +2,14 @@ package main
 
 import (
   "context"
-  "strings"
+  "github.com/ericchiang/k8s"
+  corev1 "github.com/ericchiang/k8s/apis/core/v1"
+  "github.com/ghodss/yaml"
+  log "github.com/sirupsen/logrus"
   "io/ioutil"
   "os"
   "os/signal"
-  log "github.com/sirupsen/logrus"
-  "github.com/ericchiang/k8s"
-  "github.com/ghodss/yaml"
-  corev1 "github.com/ericchiang/k8s/apis/core/v1"
+  "strings"
 )
 
 func init() {


### PR DESCRIPTION
This implements a reachability probe for endpoints. If an endpoint is not reachable, haproxy will not accept the config. To maintain the functionality of this operator with broken CRD instances, we need to check this beforehand. 

Fixes #1 